### PR TITLE
Fix "unbound variable" errors

### DIFF
--- a/assert.sh
+++ b/assert.sh
@@ -113,11 +113,11 @@ _assert_fail() {
 
 _debug() {
     [[ -z "$DEBUG" ]] && return
-    if [[ "$1" == "pass" ]]; then
+    if [[ "${1:-}" == "pass" ]]; then
         echo -n .
-    elif [[ "$1" == "fail" ]]; then
+    elif [[ "${1:-}" == "fail" ]]; then
         echo -n X
-    elif [[ "$1" == "skip" ]]; then
+    elif [[ "${1:-}" == "skip" ]]; then
         echo -n s
     else
         echo
@@ -145,7 +145,7 @@ assert() {
         return
     fi
     _result_format
-    _assert_fail "expected $expected${_indent}got $result" "$1" "$3"
+    _assert_fail "expected $expected${_indent}got $result" "$1" "${3:-}"
 }
 
 assert_contains() {
@@ -158,7 +158,7 @@ assert_contains() {
         return
     fi
     _result_format
-    _assert_fail "expected *${expected}*${_indent}got $result" "$1" "$3"
+    _assert_fail "expected *${expected}*${_indent}got $result" "$1" "${3:-}"
 }
 
 assert_raises() {
@@ -171,7 +171,7 @@ assert_raises() {
         _debug pass
         return
     fi
-    _assert_fail "program terminated with code $status instead of $expected" "$1" "$3"
+    _assert_fail "program terminated with code $status instead of $expected" "$1" "${3:-}"
 }
 
 assert_equals() {


### PR DESCRIPTION
When the parent script is using bash's `-u` and `-e` switches, assert.sh exits with an "unbound variable" error when trying to read positional arguments that don't exist. This causes the parent test script to exit prematurely, instead of indicating a failed test.

Changing the positional arguments to those that permit unspecified arguments seems to have no ill effects, and fixes the early-exiting problem.
